### PR TITLE
FR-819_health_endpoint_cache_issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,16 @@ def versions = [
     sonarPitest: '0.5'
 ]
 
+configurations.all {
+    resolutionStrategy {
+        eachDependency { DependencyResolveDetails details ->
+            if (details.requested.group in ['com.fasterxml.jackson.core', 'com.fasterxml.jackson.module', 'com.fasterxml.jackson.datatype']) {
+                details.useVersion '2.9.9'
+            }
+        }
+    }
+}
+
 dependencies {
     compile('org.springframework.boot:spring-boot-starter-actuator')
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,7 +68,7 @@ management:
     health:
       show-details: "ALWAYS"
       cache:
-        time-to-live: 5000
+        time-to-live: 1000
   endpoints:
     web:
       base-path: /


### PR DESCRIPTION
- reduced cache time to live to 1000ms.
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/FR-819
### Change description ###
Health endpoint caching issue and cleanup to remove unused dependencies
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
