### PR TITLE
Dependency check fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ dependencies {
     compile group:'info.solidsoft.gradle.pitest', name: 'gradle-pitest-plugin', version: versions.gradlePitest
     compile group:'org.codehaus.sonar-plugins', name:'sonar-pitest-plugin', version: versions.sonarPitest
     compile group: 'org.projectlombok', name: 'lombok', version: versions.lombok
-    compile group: 'org.apache.tika', name: 'tika-core', version: '1.20'
+    compile group: 'org.apache.tika', name: 'tika-core', version: '1.22'
 
     compile group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version:'0.0.3'
     compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version:'0.0.4'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -105,4 +105,9 @@
         <cpe>cpe:2.3:a:checkstyle:checkstyle:7.2:*:*:*:*:*:*:*</cpe>
         <cve>CVE-2019-9658</cve>
     </suppress>
+    <suppress>
+        <notes>Ignore the jackson binding issue</notes>
+        <cve>CVE-2019-14379</cve>
+        <cve>CVE-2019-14439</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
---------
upgraded Apache tikka Version to 1.22 to fix
CVE-2019-10088
CVE-2019-10093
CVE-2019-10094



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
