### PR TITLE
Bumping tika-core to 1.28.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,7 @@ dependencies {
 
     implementation group: 'org.apache.commons', name: 'commons-lang3', version : versions.commonsLang3
     implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: versions.pdfbox
-    implementation group: 'org.apache.tika', name: 'tika-core', version: '1.28.2'
+    implementation group: 'org.apache.tika', name: 'tika-core', version: '1.28.3'
     implementation group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 
     testImplementation group: 'com.github.tomakehurst', name:'wiremock', version: versions.wiremock


### PR DESCRIPTION
### Change description ###

Bumping tika-core to 1.28.3, fixing CVE-2022-30973

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
